### PR TITLE
P2P: defer TCP connection teardown after UDP HELLO until next houseke…

### DIFF
--- a/netsody-p2p/src/node/inner.rs
+++ b/netsody-p2p/src/node/inner.rs
@@ -476,7 +476,7 @@ impl NodeInner {
         let ack_time = ack.time.into();
         let local_addr = udp_binding.map(|binding| binding.local_addr);
 
-        super_peer.ack_rx(local_addr, src, time, ack_time, self.opts.enforce_tcp);
+        super_peer.ack_rx(local_addr, src, time, ack_time);
     }
 
     pub fn cached_time(&self) -> u64 {

--- a/netsody-p2p/src/peer/super_peer.rs
+++ b/netsody-p2p/src/peer/super_peer.rs
@@ -381,7 +381,6 @@ impl SuperPeer {
         src: SocketAddr,
         time: u64,
         ack_time: u64,
-        enforce_tcp: bool,
     ) {
         if let Some(udp_local_addr) = udp_local_addr {
             trace!("Got ACK via UDP");
@@ -400,10 +399,6 @@ impl SuperPeer {
                 self.udp_paths.pin().insert(path_key, udp_path);
             }
             self.update_best_udp_path();
-
-            if !enforce_tcp && let Some(tcp_path) = self.tcp_connection().as_ref() {
-                tcp_path.cancel_connection();
-            }
         } else {
             trace!("Got ACK via TCP");
             if let Some(tcp_path) = self.tcp_connection().as_ref() {


### PR DESCRIPTION
…eping cycle to prevent premature removal of the active TCP path before switching back to UDP